### PR TITLE
Clarify that push and pull act on branches, not repositories.

### DIFF
--- a/handouts/handout-lesson2.tex
+++ b/handouts/handout-lesson2.tex
@@ -58,10 +58,10 @@
     \itemsep\itempad
   \item \textbf{git remote add origin REPOSITORY\_URL} - Configure a local
     repository with a remote with the label 'origin'
-  \item \textbf{git push} - Synchronise changes in a local repository to a
-    remote one
-  \item \textbf{git pull} - Synchronise changes in a remote repository to a
-    local one
+  \item \textbf{git push} - Synchronise changes in the current local branch to 
+    its upstream branch
+  \item \textbf{git pull} - Synchronise changes in the upstream branch to the
+    current local one
   \item \textbf{git clone REPOSITORY\_URL} - Create a new local repository that
     is a copy of remote one
   \end{itemize}


### PR DESCRIPTION
Update handout for lesson 2 to clarify that push and pull act on the current branch, not on the whole repository. 

It might be worth to mention - maybe for a future edition, given that this course is relatively light weight - `fetch` as a way of finding out if there are changes in the remote branches before synchronising (pulling) anything. 