### PR TITLE
Typos

### DIFF
--- a/_episodes/l1-02-committing-history.md
+++ b/_episodes/l1-02-committing-history.md
@@ -20,7 +20,7 @@ keypoints:
 - A git repository is the record of the history of a project and can be created with git init
 - Git records changes to files as commits
 - Git must be explicitly told which changes to include as part of commit (known as staging changes) with git add [file]...
-- Staged changes can be stored in a commit with git add -m "commit message"
+- Staged changes can be stored in a commit with git commit -m "commit message"
 - You can check which files have been changed and/or staged with git status
 - You can see the full changes made to files with git diff for unstaged files and git diff --cached
 - The commit history of a repository can be checked with git log

--- a/_episodes/l1-03-branching-merging.md
+++ b/_episodes/l1-03-branching-merging.md
@@ -427,11 +427,11 @@ for Git to know which it should be so it has to ask you. Let's resolve it by
 choosing the version from the master branch. Edit `ingredients.md` so it looks
 like:
 ~~~
-* 1 tbsp coriander
 * 2 avocados
 * 1 lime
 * 1 tsp salt
 * 1/2 onion
+* 1 tbsp coriander
 ~~~
 
 now stage, commit and check the result:

--- a/_episodes/l1-03-branching-merging.md
+++ b/_episodes/l1-03-branching-merging.md
@@ -338,8 +338,8 @@ $ git graph
 ~~~
 {: .commands}
 ~~~
-* d5fb141 (experiment) Added salt to balance coriander
-| * 7477632 (HEAD -> master) reduce salt
+* d5fb141 (HEAD -> experiment) Added salt to balance coriander
+| * 7477632 (master) reduce salt
 | *   567307e Merge branch 'experiment'
 | |\  
 | |/  


### PR DESCRIPTION
Corrects a few typos and erros in the lessons. There are a couple of other things more related to clarification, like the issue with `^M`, using a text editor or how to use the commit hash in commands. 