### PR TITLE
Distinguish between editing files and run commands

### DIFF
--- a/_episodes/l1-03-branching-merging.md
+++ b/_episodes/l1-03-branching-merging.md
@@ -211,11 +211,16 @@ different features in parallel. You may have already spotted the typo in
 our work on the `experiment` branch. We could correct the typo with a new commit
 in `experiment` but it doesn't fit in very well here - if we decide to discard
 our experiment then we also lose the correction. Instead it makes much more
-sense to create a correcting commit in `master`:
+sense to create a correcting commit in `master`. First, move to (checkout) the master branch:
 
 ~~~
 $ git checkout master
-$ # make change to ingredients.md
+~~~
+{: .commands}
+
+Then fix the typing mistake in `ingredients.md`. And finally, commit that change:
+
+~~~
 $ git add ingredients.md
 $ git commit -m "Corrected typo in ingredients.md"
 $ git graph


### PR DESCRIPTION
Another common issue I've seen where students are clearly just copy-pasting from inside the "Commands" boxes and they copy the commented line (instead of editing the file) and don't know why it didn't work.

I've changed the first time that appears to help nail home the workflow, but left the next two because sometimes mistakes and slightly ambiguous instructions force students to think.