### PR TITLE
GitHub signup and PAT instructions

### DIFF
--- a/_episodes/l2-01-sharing_your_code.md
+++ b/_episodes/l2-01-sharing_your_code.md
@@ -66,7 +66,10 @@ Create a Personal Access Token (PAT):
 3. Keep the PAT safe, once you nagivate away from the page you won't be able to view it again.
    If you lose it, you can always regenerate it.
 
+If you're familiar with SSH keys, you can follow [these instructions][ssh-instructions] to use that alternative authentication method.
+
 [pat-instructions]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-token
+[ssh-instructions]: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account
 
 ### Private vs public repositories
 

--- a/_episodes/l2-01-sharing_your_code.md
+++ b/_episodes/l2-01-sharing_your_code.md
@@ -43,9 +43,30 @@ There are several widely used repository hosting services using Git, such as
 
 - It is very easy to use and setup.
 - It is, arguably, the most used hosting service of them all.
-- Imperial has a GitHub Organisation any Imperial staff or student can join.
-- You should have already created an account on GitHub according to the [setup
-  instructions](../setup).
+- Imperial has a GitHub Organisation any Imperial staff or student can join. You don't
+  need to join for this course but instructions to do so can be found [here][ic-github].
+
+[ic-github]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/research-support-systems/github/working-with-githubcom/
+
+### Set up your GitHub account
+
+Set up your free github account:
+
+1. Go to [www.github.com/join](https:www.github.com/join)
+2. Enter your details and click "Create an account". You can use your Imperial e-mail address,
+   but this is not mandatory.
+3. Choose the Free plan.
+4. Check your e-mail and click "Verify email address".
+5. You can fill out the questionnaire or click "skip this step".
+
+Create a Personal Access Token (PAT):
+
+1. In order to access GitHub from the command line, you will need a PAT.
+2. Follow the instructions [here][pat-instructions] to generate one. Ensure that "repo" is ticked.
+3. Keep the PAT safe, once you nagivate away from the page you won't be able to view it again.
+   If you lose it, you can always regenerate it.
+
+[pat-instructions]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-token
 
 ### Private vs public repositories
 

--- a/_episodes/l2-01-sharing_your_code.md
+++ b/_episodes/l2-01-sharing_your_code.md
@@ -52,7 +52,7 @@ There are several widely used repository hosting services using Git, such as
 
 Set up your free github account:
 
-1. Go to [www.github.com/join](https:www.github.com/join)
+1. Go to [www.github.com/join](https:www.github.com/join).
 2. Enter your details and click "Create an account". You can use your Imperial e-mail address,
    but this is not mandatory.
 3. Choose the Free plan.

--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -76,6 +76,12 @@ local one out of it or the other way around, the steps are different.
 >  `origin/main`, setting it as its upstream branch.
 > - You can check if things went well by going to GitHub: the repository there
 >   should contain all the files of your local repository.
+>
+> **Windows users:** You will be presented with a CredentialHelperSelector dialog box. 
+> Ensure "manager-core" is selected and check the box for "Always use this from now 
+> on". Press Select. From the next dialog select "Token" then paste the PAT you saved 
+> earlier and press "Sign in". On subsequent interactions with GitHub your credentials 
+> will be remembered and you will not be prompted. 
 {: .challenge}
 
 > ## Configuring a local repository from a remote

--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -58,14 +58,17 @@ local one out of it or the other way around, the steps are different.
 >   description and choose if it should be public or private, but do not add any
 >   other file (no README or licence).
 > - You will be offered a few options to populate the remote repository. We are
->   interested in the third one.
+>   interested in the third one. You will need to make sure HTTPS is selected
+>   (not SSH) for your personal access token to work.
 > - Launch a new command line interface and run `cd recipe` to navigate to the
 >   directory where you have your local repository - Then execute:
 >
 >```bash
->$ git remote add origin [address of your remote repo (should end in .git)]
+>$ git remote add origin [address of your remote repo] 
+># The address start with https:// and end in .git 
 >$ git push -u origin main
-># you will be asked to provide your GitHub username and password
+># You will be asked to provide your GitHub username and password.
+># Enter your personal access token (PAT) as your password. 
 >```
 >- The first line will set the GitHub repository as the remote for your
 > local one, calling it `origin`.

--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -65,7 +65,7 @@ local one out of it or the other way around, the steps are different.
 >
 >```bash
 >$ git remote add origin [address of your remote repo] 
-># The address start with https:// and end in .git 
+># The address should start with https:// and end in .git 
 >$ git push -u origin main
 ># You will be asked to provide your GitHub username and password.
 ># Enter your personal access token (PAT) as your password. 

--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -67,21 +67,21 @@ local one out of it or the other way around, the steps are different.
 >$ git remote add origin [address of your remote repo] 
 ># The address should start with https:// and end in .git 
 >$ git push -u origin main
-># You will be asked to provide your GitHub username and password.
-># Enter your personal access token (PAT) as your password. 
 >```
->- The first line will set the GitHub repository as the remote for your
-> local one, calling it `origin`.
->- The second line will push your main branch to a remote one called
->  `origin/main`, setting it as its upstream branch.
-> - You can check if things went well by going to GitHub: the repository there
->   should contain all the files of your local repository.
->
+> **Mac and Linux users:** You will be asked to provide your GitHub username and password.
+> Enter your personal access token (PAT) as your password.   
 > **Windows users:** You will be presented with a CredentialHelperSelector dialog box. 
 > Ensure "manager-core" is selected and check the box for "Always use this from now 
 > on". Press Select. From the next dialog select "Token" then paste the PAT you saved 
 > earlier and press "Sign in". On subsequent interactions with GitHub your credentials 
 > will be remembered and you will not be prompted. 
+>
+>- The first line above will set the GitHub repository as the remote for your
+> local one, calling it `origin`.
+>- The second line will push your main branch to a remote one called
+>  `origin/main`, setting it as its upstream branch.
+> - You can check if things went well by going to GitHub: the repository there
+>   should contain all the files of your local repository.
 {: .challenge}
 
 > ## Configuring a local repository from a remote

--- a/setup.md
+++ b/setup.md
@@ -42,7 +42,7 @@ should be able to launch Git Bash from the Start Menu. Within the window that
 launches enter the command `git --version` and press enter. You should see
 output similar to the below:
 ```
-git version 2.23.0.windows-1
+git version 2.34.1.windows-1
 ```
 
 ### MacOS
@@ -63,7 +63,7 @@ To check the installation was successful open the "Terminal" app. In the window
 that launches enter the command `git --version` and press enter. You should see
 output similar to the below:
 ```
-git version 2.25.0
+git version 2.33.0
 ```
 
 ### Linux


### PR DESCRIPTION
This PR adds instructions to create a GitHub account and for accessing GitHub from the command line using personal access tokens. Some questions I have: 

- Are the GitHub joining instructions in the right place and do they make sense? 
- Should we add any instructions on using SSH instead of HTTPS?
- Are there any Windows-specific differences we need to consider (I haven't been able to test this)?

Closes #19, closes #22.
